### PR TITLE
Update to Bevy 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["assets/*"]
 
 [dependencies]
 rusty_spine = "0.8"
-bevy = { version = "^0.15.2", default-features = false, features = [
+bevy = { version = "^0.16", default-features = false, features = [
     "bevy_render",
     "bevy_asset",
     "bevy_sprite",
@@ -21,7 +21,7 @@ thiserror = "1.0.50"
 
 [dev-dependencies]
 lerp = "0.5"
-bevy = { version = "0.15", default-features = true }
+bevy = { version = "0.16", default-features = true }
 
 [workspace]
 resolver = "2"

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A Bevy Plugin for [Spine](http://esotericsoftware.com/), utilizing [rusty_spine]
 
 ```
 [dependencies]
-bevy = "0.14"
+bevy = "0.16"
 bevy_spine = "0.10"
 ```
 
@@ -14,7 +14,7 @@ bevy_spine = "0.10"
 
 | bevy_spine | rusty_spine | bevy | spine |
 | ---------- | ----------- | ---- | ----- |
-| 0.10       | 0.8         | 0.14 | 4.2   |
+| 0.10       | 0.8         | 0.16 | 4.2   |
 | 0.9        | 0.8         | 0.13 | 4.2   |
 | 0.8        | 0.7         | 0.13 | 4.1   |
 | 0.8        | 0.7         | 0.13 | 4.1   |

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -16,7 +16,8 @@ use bevy::{
             RenderPipelineDescriptor, ShaderRef, SpecializedMeshPipelineError, VertexFormat,
         },
     },
-    sprite::{AlphaMode2d, Material2d, Material2dKey},
+    sprite::{Material2d, Material2dKey},
+    prelude::AlphaMode,
 };
 use rusty_spine::BlendMode;
 
@@ -161,8 +162,8 @@ macro_rules! material {
                 SHADER_HANDLE.into()
             }
 
-            fn alpha_mode(&self) -> AlphaMode2d {
-                AlphaMode2d::Blend
+            fn alpha_mode(&self) -> AlphaMode {
+                AlphaMode::Blend
             }
 
             fn specialize(


### PR DESCRIPTION
## Summary
- update Bevy dependency to 0.16
- update README for 0.16
- adjust materials code for new `AlphaMode`

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_b_6854c6e0123c8330a2be98f400c079b2